### PR TITLE
Add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": "^8.0",
     "ext-pdo": "*",
-    "laravel/framework": "^10.0|^11.0|^12.0"
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^12.4",


### PR DESCRIPTION
Closes #5.

Widens the `laravel/framework` constraint in `composer.json` to include `^13.0`. No code changes required — Laravel 13 does not alter the `Illuminate\Database\Connectors\PostgresConnector` contract that this package extends, and none of the L13 breaking changes (CSRF middleware rename, pagination view renames, cache serialization hardening, `Container::call` nullable behaviour) touch this package's surface area.

### Changes

```diff
-    "laravel/framework": "^10.0|^11.0|^12.0"
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
```

### Verification

Dry-run against a fresh Laravel 13 install resolves cleanly with this branch:

```
composer require laravel/framework:^13.0 --with-all-dependencies --dry-run
```

PHP requirement `^8.0` stays as-is — Laravel 13 requires PHP 8.3+, which consumers enforce themselves.

Happy to add an L13 entry to the CI matrix if you'd like that in a follow-up.